### PR TITLE
Bug fixes and improvements

### DIFF
--- a/svn-stash.py
+++ b/svn-stash.py
@@ -22,7 +22,7 @@ def execute_stash_push(target_file,filename_list):
 	if len(filename_list)>0:
 		#save the svn status into a stash
 		stash = svn_stash()
-		stash.push(target_file,filename_list)		
+		stash.push(target_file,filename_list)
 		register = svn_stash_register()
 		register.register_stash(stash)
 		register.write()
@@ -60,7 +60,7 @@ def execute_stash_show(target_file,filename_list):
 	for stash_id in register.stashes:
 		current_stash = svn_stash()
 		current_stash.load(stash_id)
-		print current_stash		
+		print current_stash
 
 def execute_stash_help(target_file,filename_list):
 	b =  "\033[1m"
@@ -98,7 +98,7 @@ def execute_svn_stash(command,target_file,filename_list):
 
 #obtain the svn status files
 def obtain_svn_status_files():
-	status_files = [] 
+	status_files = []
 	status_list = os.popen('svn st').read()
 	status_list = status_list.split("\n")
 	for line in status_list:
@@ -115,11 +115,11 @@ def main(args):
 	command = COMMAND_DEFAULT
 	if len(args)>1:
 		command = args[1]
-	
+
 	target_file = TARGET_FILE_DEFAULT
 	if len(args)>2:
 		target_file = args[2]
-	
+
 	filename_list = obtain_svn_status_files()
 	execute_svn_stash(command,target_file,filename_list)
 

--- a/svn_stash_register.py
+++ b/svn_stash_register.py
@@ -112,12 +112,18 @@ class svn_stash:
 		result = ""
 		if os.path.exists(SVN_STASH_DIR):
 			for target_file in self.files:
-				randkey = self.files[target_file]
-				result = os.popen("patch -p0 < " + SVN_STASH_DIR + "/" + str(randkey) + ".stash.patch").read()
-				result += os.popen("rm " + SVN_STASH_DIR + "/" + str(randkey) + ".stash.patch").read()
-				#print "pop " + target_file
+				randkey  = self.files[target_file]
+				filepath = SVN_STASH_DIR + "/" + str(randkey) + ".stash.patch"
+
+				if os.path.isfile(filepath):
+					result  = os.popen("patch -p0 < " + filepath).read()
+					result += os.popen("rm " + filepath).read()
+					#print "pop " + target_file
+
 			#delete the file of svn_stash
-			result += os.popen("rm " + SVN_STASH_DIR + "/" + str(self.key)).read()
+			filepath = SVN_STASH_DIR + "/" + str(self.key)
+			if os.path.isfile(filepath):
+				result += os.popen("rm " + filepath).read()
 
 	def write(self):
 		#Create file for svn stash

--- a/svn_stash_register.py
+++ b/svn_stash_register.py
@@ -117,17 +117,9 @@ class svn_stash:
 
 				if os.path.isfile(filepath):
 					result  = os.popen("patch -p0 < " + filepath).read()
-					result += os.popen("rm " + filepath).read()
 					#print "pop " + target_file
 				else:
-					print 'randFile cannot be found, patch failed.'
-
-			#delete the file of svn_stash
-			filepath = SVN_STASH_DIR + "/" + str(self.key)
-			if os.path.isfile(filepath):
-				result += os.popen("rm " + filepath).read()
-			else:
-				print 'registerFile cannot be found.'
+					print 'Patch file cannot be found.'
 
 	def write(self):
 		#Create file for svn stash

--- a/svn_stash_register.py
+++ b/svn_stash_register.py
@@ -61,7 +61,7 @@ class svn_stash_register:
    				f.writelines(content)
    				f.close()
 		except IOError as e:
-   			print 'registerFile cannot be created.'  
+			print 'registerFile cannot be created.'
 
    	def obtain_last_stash(self):
    		length = len(self.stashes)
@@ -137,12 +137,17 @@ class svn_stash:
    			print 'randFile cannot be created.'
 
    	def clear(self):
-   		result = ""
+		result = ""
 		if os.path.exists(SVN_STASH_DIR):
-			for target_file in self.files:  
-				randkey = self.files[target_file] 		
-   				result += os.popen("rm " + SVN_STASH_DIR + "/" + str(randkey) + ".stash.patch").read()
-   			result += os.popen("rm " + SVN_STASH_DIR + "/" + str(self.key)).read()
+			for target_file in self.files:
+				randkey  = self.files[target_file]
+				filepath = SVN_STASH_DIR + "/" + str(randkey) + ".stash.patch"
+				if os.path.isfile(filepath):
+					result += os.popen("rm " + filepath).read()
+
+			filepath = SVN_STASH_DIR + "/" + str(self.key)
+			if os.path.isfile(filepath):
+				result += os.popen("rm " + filepath).read()
 
    	def load(self,stash_id):
    		try:
@@ -173,7 +178,7 @@ class svn_stash:
    		for filename in self.files:
    			try:
    				real_dir =  filename + ".stash.patch"
-				current_dir = SVN_STASH_DIR + "/" + self.files[filename] + ".stash.patch"	
+				current_dir = SVN_STASH_DIR + "/" + self.files[filename] + ".stash.patch"
 				content += print_hr()
 				content += "file " + real_dir
 				content += print_hr()
@@ -210,6 +215,6 @@ def is_a_current_stash(stash_id):
 	stash_dir_parts = stash.root_url.split("/")
 	stash_dir_parts = stash_dir_parts[:len(current_dir_parts)]
 	stash_dir = "/".join(stash_dir_parts)
-	if ".svn" in os.listdir(CURRENT_DIR):	
+	if ".svn" in os.listdir(CURRENT_DIR):
 		return stash_dir == CURRENT_DIR
 	return False

--- a/svn_stash_register.py
+++ b/svn_stash_register.py
@@ -119,11 +119,15 @@ class svn_stash:
 					result  = os.popen("patch -p0 < " + filepath).read()
 					result += os.popen("rm " + filepath).read()
 					#print "pop " + target_file
+				else:
+					print 'randFile cannot be found, patch failed.'
 
 			#delete the file of svn_stash
 			filepath = SVN_STASH_DIR + "/" + str(self.key)
 			if os.path.isfile(filepath):
 				result += os.popen("rm " + filepath).read()
+			else:
+				print 'registerFile cannot be found.'
 
 	def write(self):
 		#Create file for svn stash
@@ -150,10 +154,14 @@ class svn_stash:
 				filepath = SVN_STASH_DIR + "/" + str(randkey) + ".stash.patch"
 				if os.path.isfile(filepath):
 					result += os.popen("rm " + filepath).read()
+				else:
+					print 'randFile cannot be found.'
 
 			filepath = SVN_STASH_DIR + "/" + str(self.key)
 			if os.path.isfile(filepath):
 				result += os.popen("rm " + filepath).read()
+			else:
+				print 'registerFile cannot be found.'
 
    	def load(self,stash_id):
    		try:

--- a/svn_stash_register.py
+++ b/svn_stash_register.py
@@ -116,7 +116,7 @@ class svn_stash:
 				filepath = SVN_STASH_DIR + "/" + str(randkey) + ".stash.patch"
 
 				if os.path.isfile(filepath):
-					result  = os.popen("patch -p0 < " + filepath).read()
+					result  = os.popen("svn patch " + filepath).read()
 					#print "pop " + target_file
 				else:
 					print 'Patch file cannot be found.'


### PR DESCRIPTION
I faced a few problems using svn-stash in a Cygwin environment:  

The `svn-stash pop` command always throws **rm: cannot remove blablah: No such file or directory** errors _(2 times to be specific)_. The corresponding method should not delete the stash files as it's already followed by a `delete_stash()` call in `execute_stash_pop()`.  

Another issue is that this command always fails in patching stashed files, replacing `patch -p0 < FILE` by a `svn patch FILE` resolved my problem.  

This pull request should solve these two issues, I couldn't find the time to test it on another platform but it works fine in Cygwin.
